### PR TITLE
Fix deprecation message with newer Ember versions

### DIFF
--- a/app/templates/components/page-progress.hbs
+++ b/app/templates/components/page-progress.hbs
@@ -2,7 +2,7 @@
   <div
     class="bar"
     data-test-id="data-test-page-progress-bar"
-    style={{barStyle}}
+    style={{this.barStyle}}
   >
   </div>
 </div>


### PR DESCRIPTION
In our app running Ember 3.26.1, we keep having this deprecation message:

> The `barStyle` property was used in the template for the `my-app/templates/components/page-progress.hbs` component without using `this`. This fallback behavior has been deprecated, all properties must be looked up on `this` when used in the template: {{this.barStyle}} [deprecation id: this-property-fallback] See https://deprecations.emberjs.com/v3.x#toc_this-property-fallback for more details.